### PR TITLE
Removed separate msdocs search & added search listing link

### DIFF
--- a/ContactsBot/Modules/Documentation.cs
+++ b/ContactsBot/Modules/Documentation.cs
@@ -13,19 +13,11 @@ using Newtonsoft.Json;
 
 namespace ContactsBot.Modules
 {
-    [Group("docs")]
     public class Documentation : ModuleBase
     {
         private const string MSDNIcon = "http://i.imgur.com/LCr4b6P.png";
-        private const string MSDocsIcon = "http://i.imgur.com/GSXfzSU.jpg";
 
-        private enum ReplyType
-        {
-            MSDN,
-            MSDocs
-        }
-
-        [Command("msdn")]
+        [Command("docs")]
         public async Task Msdn([Summary("The query to search for")] [Remainder] string query)
         {
             try
@@ -41,8 +33,7 @@ namespace ContactsBot.Modules
                         OriginalQuery = query,
                         Title = d.Descendants(XName.Get("title", "")).FirstOrDefault()?.Value,
                         Description = d.Descendants(XName.Get("description", "")).FirstOrDefault()?.Value,
-                        Url = d.Descendants(XName.Get("link", "")).FirstOrDefault()?.Value,
-                        ReplyType = ReplyType.MSDN
+                        Url = d.Descendants(XName.Get("link", "")).FirstOrDefault()?.Value
                     })
                     .FirstOrDefault();
 
@@ -62,47 +53,6 @@ namespace ContactsBot.Modules
             }
         }
 
-        [Command("msdocs")]
-        public async Task Docs([Summary("The query to search for")] [Remainder] string query)
-        {
-            try
-            {
-                var request = HttpWebRequest.CreateHttp($"https://docs.microsoft.com/api/search?search={Uri.EscapeDataString(query)}&locale=en-us&$top=10");
-                using (StreamReader reader = new StreamReader((await request.GetResponseAsync()).GetResponseStream()))
-                {
-                    var response = JObject.Parse(reader.ReadToEnd());
-                    var result = response.First.First.First();
-
-                    var item = new QueryResponse
-                    {
-                        OriginalQuery = query,
-                        Title = result["title"].Value<string>(),
-                        Description = result["description"].Value<string>(),
-                        Url = result["url"].Value<string>(),
-                        ReplyType = ReplyType.MSDocs
-                    };
-
-                    await ReplyWithResponse(item);
-                }
-            }
-            catch (WebException)
-            {
-                await ReplyAsync("Sorry, there was a network issue.");
-            }
-            catch (JsonException)
-            {
-                await ReplyAsync("There was a problem parsing the JSON response from MSDocs.");
-            }
-            catch (IOException)
-            {
-                await ReplyAsync("There was an issue in reading the response from MSDocs.");
-            }
-            catch (Exception)
-            {
-                await ReplyAsync("Something weird happened.");
-            }
-        }
-
         private async Task ReplyWithResponse(QueryResponse response)
         {
             var embed = new Discord.EmbedBuilder
@@ -111,9 +61,9 @@ namespace ContactsBot.Modules
                 Description = WebUtility.HtmlDecode(response.Description),
                 Url = response.Url,
                 Color = new Discord.Color(104, 33, 122),
-                Thumbnail = new Discord.EmbedThumbnailBuilder()
+                Thumbnail = new Discord.EmbedThumbnailBuilder
                 {
-                    Url = (response.ReplyType == ReplyType.MSDN ? MSDNIcon : MSDocsIcon)
+                    Url = MSDNIcon
                 }
             };
 
@@ -127,8 +77,6 @@ namespace ContactsBot.Modules
             public string Title { get; set; }
             public string Description { get; set; }
             public string Url { get; set; }
-
-            public ReplyType ReplyType { get; set; }
         }
     }
 }


### PR DESCRIPTION
Turns out MSDN already searches docs.microsoft.com (among other sources), so I removed the separate msdocs search and merged the command into one "docs" command (also aliased to "msdn"). 

Additionally, I added the source of the results to the "author" bit in the embed, and made it link to the search listing, as well as added some more detailed error messages.