### PR TITLE
Added Reaction Events

### DIFF
--- a/ContactsBot/Bot/ContactsBot.cs
+++ b/ContactsBot/Bot/ContactsBot.cs
@@ -213,6 +213,8 @@ namespace ContactsBot
         {
             if (arg3.Emoji.Name == "👍")
             {
+                private static Logger KarmasModuleLogger { get; } = LogManager.GetCurrentClassLogger();
+
                 try
                 {
                     using (var context = new ContactsBotDbContext())
@@ -240,6 +242,7 @@ namespace ContactsBot
         [Summary("This event will keep track of Karma removed from users")]
         private async Task OnReactionRemoved(ulong arg1, Optional<SocketUserMessage> arg2, SocketReaction arg3)
         {
+            private static Logger KarmasModuleLogger { get; } = LogManager.GetCurrentClassLogger();
 
             if (arg3.Emoji.Name == "👍")
             {


### PR DESCRIPTION
Instead of using a command to keep track of karma, using the :thumbsup: reaction could be a simpler alternative. I also added a OnRemovedReaction event in order to remove any mistakenly given karma, or prevent people from farming karma off 1 message.

Only problems I encountered was only the yellow :thumbsup: will work, any other color tone will not be giving karma to the user, tried to work around it with IDs but for some reason every emote (no matter the skin tone) returned 0.